### PR TITLE
fix(pre-commit): replace confusing hint after finish checking

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -20,4 +20,4 @@ npx lint-staged || {
   exit 1
 }
 
-echo "规范检查通过，代码已成功提交！"
+echo "代码已通过规范检查！"


### PR DESCRIPTION
This pull request makes a minor update to the `.husky/pre-commit` script, rephrasing the success message displayed after code passes lint checks.