### PR TITLE
chore(git): provide git attributes to normalize eol and lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+# Default to LF line endings for all text files
+* text=auto eol=lf
+
+# Infra & DevOps
+*.sh text eol=lf
+Dockerfile* text eol=lf
+.dockerignore text eol=lf
+docker-compose* text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+.env* text eol=lf
+
+## Except Windows batch files
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Frontend
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.svg text eol=lf
+.eslintrc* text eol=lf
+.prettierrc* text eol=lf
+
+# Backend
+*.java text eol=lf
+*.gradle text eol=lf
+*.properties text eol=lf
+*.xml text eol=lf
+gradlew text eol=lf
+
+# Large File Storage (LFS)
+## Images
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text
+
+## Fonts
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.woff filter=lfs diff=lfs merge=lfs -text
+*.woff2 filter=lfs diff=lfs merge=lfs -text
+*.eot filter=lfs diff=lfs merge=lfs -text
+*.otf filter=lfs diff=lfs merge=lfs -text
+
+## Archives & Media
+*.pdf filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.tar.gz filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+
+## Backend-generated binary packages (typically ignored, just in case)
+*.jar filter=lfs diff=lfs merge=lfs -text
+*.war filter=lfs diff=lfs merge=lfs -text
+
+## Exceptions (not treated as binary)
+**/gradle/wrapper/gradle-wrapper.jar -filter -diff -merge text=false


### PR DESCRIPTION
This pull request introduces a new `.gitattributes` file to standardize line endings and configure Git LFS for large files. The main goal is to ensure consistent handling of files across different environments and improve repository performance with large assets.

File normalization and LFS configuration:

* Enforces LF line endings for most text files, with exceptions for Windows batch files (`*.bat`, `*.cmd`), which use CRLF. (.gitattributes)
* Sets up Git LFS for common image, font, archive, media, and backend binary file types to improve handling of large files. (.gitattributes)
* Explicitly disables LFS for `gradle-wrapper.jar` in the `gradle/wrapper` directory to avoid treating it as a binary asset. (.gitattributes)