### PR TITLE
chore(github): add CODEOWNERS file for .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/   ugamegerm.chen@gmail.com


### PR DESCRIPTION
This pull request makes a minor update to the `.github/CODEOWNERS` file, assigning ownership of the `.github/` directory to @Christoph-UGameGerm 